### PR TITLE
Adjust OpenAPI behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Azure DevOps Build Pipeline
 - HttpDependencies / Refit w/HttpClientOptions support.
 - Multiple ApiVersion support for NSwag
+- Ability to disable Swagger from configuration
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Azure ARM Template
 - Azure DevOps Build Pipeline
 - HttpDependencies / Refit w/HttpClientOptions support.
+- Multiple ApiVersion support for NSwag
 
 ### Changed
 

--- a/src/Content/Backend/LocalSettings.Development.json
+++ b/src/Content/Backend/LocalSettings.Development.json
@@ -36,5 +36,8 @@
       "Microsoft": "Warning",
       "Microsoft.Hosting.Lifetime": "Information"
     }
+  },
+  "Backend": {
+    "EnableSwagger": true
   }
 }

--- a/src/Content/Backend/NV.Templates.Backend.Core/Configuration/BackendOptions.cs
+++ b/src/Content/Backend/NV.Templates.Backend.Core/Configuration/BackendOptions.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NV.Templates.Backend.Core.Configuration
+{
+    /// <summary>
+    /// Backend Options.
+    /// </summary>
+    public class BackendOptions
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether Swagger is accessible or not.
+        /// </summary>
+        public bool EnableSwagger { get; set; }
+    }
+}

--- a/src/Content/Backend/NV.Templates.Backend.Core/CoreServiceCollectionExtensions.cs
+++ b/src/Content/Backend/NV.Templates.Backend.Core/CoreServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using HttpTracing;
 using Microsoft.Extensions.Configuration;
+using NV.Templates.Backend.Core.Configuration;
 using NV.Templates.Backend.Core.General;
 
 namespace Microsoft.Extensions.DependencyInjection
@@ -11,7 +12,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         public static IServiceCollection AddCore(this IServiceCollection services, IConfiguration configuration)
         {
-            // services.BindOptionsToConfigurationAndValidate<>(configuration);
+            services.BindOptionsToConfigurationAndValidate<BackendOptions>(configuration);
 
             services.AddHttpTracingToAllHttpClients((sp, builder) =>
             {

--- a/src/Content/Backend/NV.Templates.Backend.Core/Framework/ApplicationBuilderExtensions.cs
+++ b/src/Content/Backend/NV.Templates.Backend.Core/Framework/ApplicationBuilderExtensions.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NV.Templates.Backend.Core.Configuration;
+
+namespace Microsoft.AspNetCore.Builder
+{
+    public static class ApplicationBuilderExtensions
+    {
+        public static IApplicationBuilder UseCommonOpenApi(this IApplicationBuilder app)
+        {
+            var conf = app.ApplicationServices.GetService<IOptions<BackendOptions>>();
+
+            if (conf?.Value.EnableSwagger ?? false)
+            {
+                app.UseOpenApi();
+                app.UseSwaggerUi3(configure =>
+                {
+                    configure.DocExpansion = "list";
+#if Auth
+                    configure.OAuth2Client = app.ApplicationServices.GetRequiredService<IOptions<NSwag.AspNetCore.OAuth2ClientSettings>>().Value;
+#endif
+                });
+            }
+
+            return app;
+        }
+    }
+}

--- a/src/Content/Backend/NV.Templates.Backend.Core/NV.Templates.Backend.Core.csproj
+++ b/src/Content/Backend/NV.Templates.Backend.Core/NV.Templates.Backend.Core.csproj
@@ -10,12 +10,14 @@
 
   <ItemGroup>
     <PackageReference Include="HttpTracing" Version="1.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="3.1.3" />
+    <PackageReference Include="NSwag.AspNetCore" Version="13.3.0" />
     <PackageReference Include="Refit" Version="5.1.54" />
     <PackageReference Include="Scrutor" Version="3.2.0" />
     <PackageReference Include="System.Text.Json" Version="4.7.1" />

--- a/src/Content/Backend/NV.Templates.Backend.Web/Framework/EndpointRouteBuilderExtensions.cs
+++ b/src/Content/Backend/NV.Templates.Backend.Web/Framework/EndpointRouteBuilderExtensions.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using NV.Templates.Backend.Core.Configuration;
 using NV.Templates.Backend.Web.Framework.Middlewares;
 
 namespace Microsoft.AspNetCore.Routing
@@ -42,6 +44,15 @@ namespace Microsoft.AspNetCore.Routing
         /// Maps root requests("/") to OpenApi UI ("/swagger").
         /// </summary>
         public static IEndpointRouteBuilder MapRootToOpenApiUi(this IEndpointRouteBuilder endpoints)
-            => endpoints.MapGetRedirect("/", "/swagger");
+        {
+            var conf = endpoints.ServiceProvider.GetService(typeof(IOptions<BackendOptions>)) as IOptions<BackendOptions>;
+
+            if (!(conf?.Value.EnableSwagger ?? false))
+            {
+                return endpoints;
+            }
+
+            return endpoints.MapGetRedirect("/", "/swagger");
+        }
     }
 }

--- a/src/Content/Backend/NV.Templates.Backend.Web/NV.Templates.Backend.Web.csproj
+++ b/src/Content/Backend/NV.Templates.Backend.Web/NV.Templates.Backend.Web.csproj
@@ -26,7 +26,6 @@
     <!--#if (SPA) -->
     <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="3.1.3" />
     <!--#endif -->
-    <PackageReference Include="NSwag.AspNetCore" Version="13.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Content/Backend/NV.Templates.Backend.Web/RestApi/RestApiServiceCollectionExtensions.cs
+++ b/src/Content/Backend/NV.Templates.Backend.Web/RestApi/RestApiServiceCollectionExtensions.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 })
                 .AddVersionedApiExplorer(options =>
                 {
-                    options.GroupNameFormat = "'v'V";
+                    options.GroupNameFormat = "'v'VV";
                     options.SubstituteApiVersionInUrl = true;
                 })
                 .AddControllers(options =>

--- a/src/Content/Backend/NV.Templates.Backend.Web/RestApi/SampleController.cs
+++ b/src/Content/Backend/NV.Templates.Backend.Web/RestApi/SampleController.cs
@@ -19,6 +19,8 @@ namespace NV.Templates.Backend.Web.RestApi
     {
         [HttpGet]
         [Description("Query samples")]
+        [ApiVersion("1.0")]
+        [ApiVersion("2.0")]
         public async Task<ContinuationEnumerableModel<SampleModel>> FindSamples([FromQuery] SampleQuery query)
         {
             return Enumerable.Empty<SampleModel>()
@@ -28,7 +30,20 @@ namespace NV.Templates.Backend.Web.RestApi
 
         [HttpGet("{id}")]
         [Description("Get a sample")]
+        [ApiVersion("1.0")]
         public async Task<SampleModel> GetSample(string id)
+        {
+            return new SampleModel
+            {
+                Id = id,
+                Name = "Foo",
+            };
+        }
+
+        [HttpGet("{id}")]
+        [Description("Get a sample - v2")]
+        [ApiVersion("2.0")]
+        public async Task<SampleModel> GetSampleV2(string id)
         {
             return new SampleModel
             {
@@ -39,6 +54,8 @@ namespace NV.Templates.Backend.Web.RestApi
 
         [HttpPost]
         [Description("Create a sample")]
+        [ApiVersion("1.0")]
+        [ApiVersion("2.0")]
         public async Task<ActionResult<SampleModel>> CreateSample([FromBody] SampleModelAttributes model)
         {
             var createdModel = new SampleModel
@@ -52,6 +69,8 @@ namespace NV.Templates.Backend.Web.RestApi
 
         [HttpPut("{id}")]
         [Description("Update a sample")]
+        [ApiVersion("1.0")]
+        [ApiVersion("2.0")]
         public async Task<SampleModel> UpdateSample(string id, [FromBody] SampleModelAttributes model)
         {
             var updatedModel = new SampleModel
@@ -65,6 +84,8 @@ namespace NV.Templates.Backend.Web.RestApi
 
         [HttpPatch("{id}")]
         [Description("Update a sample")]
+        [ApiVersion("1.0")]
+        [ApiVersion("2.0")]
         public async Task<SampleModel> UpdateSample(string id, [FromBody] JsonPatchDocument<SampleModelAttributes> patch)
         {
             var existingModel = new SampleModel
@@ -79,6 +100,8 @@ namespace NV.Templates.Backend.Web.RestApi
 
         [HttpDelete("{id}")]
         [Description("Delete a sample")]
+        [ApiVersion("1.0")]
+        [ApiVersion("2.0")]
         public async Task<IActionResult> DeleteSample(string id)
         {
             return NoContent();

--- a/src/Content/Backend/NV.Templates.Backend.Web/Startup.cs
+++ b/src/Content/Backend/NV.Templates.Backend.Web/Startup.cs
@@ -88,14 +88,8 @@ namespace NV.Templates.Backend.Web
 #endif
             });
 
-            app.UseOpenApi()
-               .UseSwaggerUi3(configure =>
-                {
-                    configure.DocExpansion = "list";
-#if Auth
-                    configure.OAuth2Client = app.ApplicationServices.GetRequiredService<IOptions<NSwag.AspNetCore.OAuth2ClientSettings>>().Value;
-#endif
-                });
+            app.UseCommonOpenApi();
+
 #if SPA
             app.UseSpaStaticFiles();
             app.UseSpa(spa =>


### PR DESCRIPTION
GitHub Issue: #
None

## Proposed Changes
- Add support of multiple ApiVersion using NSwag
- Add ability to disable Swagger from configuration

## What is the current behavior?
- NSwag is not working at all if we specify more than 1 ApiVersion
- Swagger is always enabled and we should be able to disable it depending on context (especially in production environments) 

## Checklist

Please check if your PR fulfills the following requirements:

- [X] Documentation has been added/updated
- [ ] ~~Automated Unit / Integration tests for the changes have been added/updated~~
- [X] Contains **NO** breaking changes
- [X] Updated the Changelog
- [ ] ~~Associated with an issue~~

## Other information
NA

