### PR TITLE
Add "properties" section for Redis cache arm definition

### DIFF
--- a/src/Content/Backend/azure.azrm.json
+++ b/src/Content/Backend/azure.azrm.json
@@ -249,6 +249,13 @@
         "environment": "[parameters('environment')]",
         "billTo": "[parameters('billTo')]",
         "managedBy": "[parameters('managedBy')]"
+      },
+      "properties": {
+        "sku": {
+          "name": "[parameters('cacheSku')]",
+          "family": "[parameters('cacheSkuFamily')]",
+          "capacity": "[parameters('cacheCapacity')]"
+        }
       }
     },
     {


### PR DESCRIPTION
GitHub Issue: #
NA

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

 - Bug fix 
 - Build or CI related changes 



## What is the current behavior?
Arm template definition for redis doesn't pass the deploy arm template task validation for the redis component


## What is the new behavior?
Add the "properties" section in the redis arm definition

` "properties": {
        "sku": {
          "name": "[parameters('cacheSku')]",
          "family": "[parameters('cacheSkuFamily')]",
          "capacity": "[parameters('cacheCapacity')]"
        }
} `

## Checklist

Please check if your PR fulfills the following requirements:

- [ ] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [x] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

